### PR TITLE
Update for XAML UI of signtool

### DIFF
--- a/AutoInsertPin/AutoInsertPin.csproj
+++ b/AutoInsertPin/AutoInsertPin.csproj
@@ -8,10 +8,25 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>AutoInsertPin</RootNamespace>
     <AssemblyName>AutoInsertPin</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -23,7 +38,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,41 +47,35 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-    <LangVersion>7.1</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
-  </PropertyGroup>
-  <PropertyGroup>
-    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="UIAutomationClient" />
-    <Reference Include="UIAutomationTypes" />
-    <Reference Include="WindowsBase" />
+    <None Include="App.config" />
+    <None Include="Properties\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.TestApi">
-      <Version>0.6.0</Version>
-    </PackageReference>
+    <Reference Include="System" />
+    <Reference Include="System.Windows" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="UIAutomationClient" />
+    <Reference Include="UIAutomationTypes" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
-    <None Include="app.manifest" />
+    <BootstrapperPackage Include=".NETFramework,Version=v4.8.1">
+      <Visible>False</Visible>
+      <ProductName>Microsoft .NET Framework 4.8.1 %28x86 and x64%29</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/AutoInsertPin/Program.cs
+++ b/AutoInsertPin/Program.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Test.Input;
+﻿// Usage AutoInsertPin.exe [pin]
+// If the pin is not supplied on the command line, it will be prompted for.
+// Modified to work with the XAML UI of signtool.exe
+
 using System;
 using System.Threading.Tasks;
 using System.Windows.Automation;
@@ -10,11 +13,18 @@ namespace AutoInsertPin
     {
         static async Task Main(string[] args)
         {
+            string pin;
+
             if (args.Length == 0)
             {
-                Console.Error.WriteLine("Error: Not passed the password as first argument.");
-                return;
+                Console.WriteLine("Enter PIN:");
+                pin = Console.ReadLine();
+
+                if (pin.Length == 0)
+                    return;
             }
+            else
+                pin = args[0];
 
             Console.WriteLine("Waiting for windows. Press Ctrl+C to finish monitoring windows...");
 
@@ -23,34 +33,30 @@ namespace AutoInsertPin
                 try
                 {
                     var window = AutomationElement.RootElement.FindFirst(TreeScope.Children, new PropertyCondition(AutomationElement.NameProperty, "Windows Security"));
+                    await Task.Delay(1000);
                     if (window == null)
-                    {
-                        await Task.Delay(1000);
                         continue;
 
-                    }
-                    await Task.Delay(1000);
+                    // Console.WriteLine("Located window");
 
-                    Console.WriteLine("Located window");
-
-                    var editControl = window.FindFirst(TreeScope.Descendants, new PropertyCondition(AutomationElement.NameProperty, "PIN"));
+                    var editControl = window.FindFirst(TreeScope.Descendants, new PropertyCondition(AutomationElement.ControlTypeProperty, ControlType.Edit));
                     if (editControl == null)
                         continue;
 
                     editControl.SetFocus();
-                    SendKeys.SendWait("^(a)");
+                    SendKeys.SendWait("^(a)");      // select all
                     await Task.Delay(250);
-                    SendKeys.SendWait("{DELETE}");
+                    SendKeys.SendWait("{DELETE}");  // delete
                     await Task.Delay(250);
-                    SendKeys.SendWait(args[0]);
+                    SendKeys.SendWait(pin);         // fill in the PIN
                     await Task.Delay(250);
 
                     var okControl = window.FindFirst(TreeScope.Descendants, new PropertyCondition(AutomationElement.NameProperty, "OK"));
                     if (okControl == null)
                         continue;
 
-                    Mouse.MoveTo(new System.Drawing.Point((int)okControl.GetClickablePoint().X, (int)okControl.GetClickablePoint().Y));
-                    Mouse.Click(MouseButton.Left);
+                    var invokePattern = okControl.GetCurrentPattern(InvokePattern.Pattern) as InvokePattern;
+                    invokePattern.Invoke();         // click OK
 
                     await Task.Delay(1000);
                 }

--- a/AutoInsertPin/app.config
+++ b/AutoInsertPin/app.config
@@ -1,3 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1" />
+    </startup>
+</configuration>

--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@
 
 With this tool, you can auto-fill the PIN code in the  Windows Security Smart Card dialog box.
 
-If you're using a yubikey or a smart card singing device for code signing with EV code signing certificates, you've to type the PIN code of the key each time a new process uses the key to sign the file.
-This project types the PIN and accepts the dialog automatically for you so you can do an unattended build.
+If you're using a yubikey or a smart card signing device for code signing with EV code signing certificates, you've got to type the PIN code of the key each time a new process uses the key to sign the file.
 
-This project is based on [UI Automation](https://docs.microsoft.com/en-us/dotnet/framework/ui-automation/ui-automation-overview) and uses the Microsoft.TestApi NuGet package to send commands to the buttons.
+This project uses [UI Automation](https://docs.microsoft.com/en-us/dotnet/framework/ui-automation/ui-automation-overview) to type the PIN and accept the dialog automatically for you so you can do an unattended build.
+
+Usage: AutoInsertPin.exe [PIN]
+
+If the pin is not entered on the command line, it will be prompted for.
+
 The application is based on the ideas of [An introduction to UI Automation - with spooky spirographs](http://blog.functionalfun.net/2009/06/introduction-to-ui-automation-with.html)


### PR DESCRIPTION
The original doesn't work with the XAML UI of signtool.  This update does and uses .Net Framework 4.8.1.